### PR TITLE
Fix autoloader mapping for lib namespace

### DIFF
--- a/scripts/analyze_sales_pitch.php
+++ b/scripts/analyze_sales_pitch.php
@@ -8,6 +8,24 @@ spl_autoload_register(function ($class) {
 
     $relativeClass = substr($class, strlen($prefix));
     $relativePath = str_replace('\\', '/', $relativeClass) . '.php';
+
+    $namespaceRoots = [
+        'Lib\\' => __DIR__ . '/../lib/',
+    ];
+
+    foreach ($namespaceRoots as $namespacePrefix => $baseDir) {
+        if (strncmp($relativeClass, $namespacePrefix, strlen($namespacePrefix)) === 0) {
+            $trimmedClass = substr($relativeClass, strlen($namespacePrefix));
+            $mappedPath = str_replace('\\', '/', $trimmedClass) . '.php';
+            $mappedFile = $baseDir . $mappedPath;
+
+            if (file_exists($mappedFile)) {
+                require $mappedFile;
+                return;
+            }
+        }
+    }
+
     $locations = [
         __DIR__ . '/../src/' . $relativePath,
         __DIR__ . '/../lib/' . $relativePath,


### PR DESCRIPTION
## Summary
- update the CLI autoloader so App\\Lib classes resolve from the lib/ directory before falling back to default lookups

## Testing
- php scripts/analyze_sales_pitch.php --config=/tmp/test-config.php --pitch=demo

------
https://chatgpt.com/codex/tasks/task_e_68d6c79207808325865c73e9ebff897a