### PR TITLE
Add local video processing option to analysis CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,20 @@ php scripts/analyze_sales_pitch.php \
     --limit=1
 ```
 
-- `--pitch` corresponds to a key defined in `google_drive.folder_mappings`.
+- `--pitch` corresponds to a key defined in `google_drive.folder_mappings` (or is optional when using `--local-dir`).
 - `--limit` determines how many recent files to process from the folder.
+- `--local-dir` lets you process the newest files from a local directory instead of Google Drive.
+
+To run the analysis against videos stored locally, provide a directory path:
+
+```bash
+php scripts/analyze_sales_pitch.php \
+    --config=config/config.php \
+    --local-dir=/path/to/videos \
+    --limit=1
+```
+
+When `--local-dir` is provided, the script sorts files by their modification time and processes the most recent entries without downloading from Google Drive.
 
 Transcripts will be stored under `storage/transcripts/` and the Gemini report will be saved to `storage/reports/` with matching base filenames.
 

--- a/scripts/analyze_sales_pitch.php
+++ b/scripts/analyze_sales_pitch.php
@@ -8,6 +8,24 @@ spl_autoload_register(function ($class) {
 
     $relativeClass = substr($class, strlen($prefix));
     $relativePath = str_replace('\\', '/', $relativeClass) . '.php';
+
+    $namespaceRoots = [
+        'Lib\\' => __DIR__ . '/../lib/',
+    ];
+
+    foreach ($namespaceRoots as $namespacePrefix => $baseDir) {
+        if (strncmp($relativeClass, $namespacePrefix, strlen($namespacePrefix)) === 0) {
+            $trimmedClass = substr($relativeClass, strlen($namespacePrefix));
+            $mappedPath = str_replace('\\', '/', $trimmedClass) . '.php';
+            $mappedFile = $baseDir . $mappedPath;
+
+            if (file_exists($mappedFile)) {
+                require $mappedFile;
+                return;
+            }
+        }
+    }
+
     $locations = [
         __DIR__ . '/../src/' . $relativePath,
         __DIR__ . '/../lib/' . $relativePath,
@@ -24,21 +42,26 @@ spl_autoload_register(function ($class) {
 use App\Config;
 use App\SpeechAnalysisService;
 
-$options = getopt('', ['config:', 'pitch:', 'limit::']);
+$options = getopt('', ['config:', 'pitch::', 'limit::', 'local-dir::']);
 
-if (!$options || empty($options['config']) || empty($options['pitch'])) {
-    fwrite(STDERR, "Usage: php analyze_sales_pitch.php --config=/path/to/config.php --pitch=key [--limit=1]\n");
+$localDir = $options['local-dir'] ?? null;
+
+if (!$options || empty($options['config']) || ($localDir === null && empty($options['pitch']))) {
+    fwrite(
+        STDERR,
+        "Usage: php analyze_sales_pitch.php --config=/path/to/config.php [--pitch=key] [--limit=1] [--local-dir=/videos]\n"
+    );
     exit(1);
 }
 
 $configPath = $options['config'];
-$pitchKey = $options['pitch'];
+$pitchKey = $options['pitch'] ?? 'local';
 $limit = isset($options['limit']) ? (int) $options['limit'] : 1;
 
 try {
     $config = new Config($configPath);
     $service = new SpeechAnalysisService($config);
-    $results = $service->processPitch($pitchKey, $limit);
+    $results = $service->processPitch($pitchKey, $limit, $localDir);
     echo json_encode($results, JSON_PRETTY_PRINT) . PHP_EOL;
 } catch (Throwable $e) {
     fwrite(STDERR, 'Error: ' . $e->getMessage() . PHP_EOL);

--- a/src/SpeechAnalysisService.php
+++ b/src/SpeechAnalysisService.php
@@ -10,7 +10,7 @@ use App\Lib\WhisperTranscriber;
 class SpeechAnalysisService
 {
     private Config $config;
-    private GoogleDriveClient $driveClient;
+    private ?GoogleDriveClient $driveClient;
     private VideoProcessor $videoProcessor;
     private WhisperTranscriber $transcriber;
     private GeminiClient $geminiClient;
@@ -19,7 +19,7 @@ class SpeechAnalysisService
     {
         $this->config = $config;
         $credentialsPath = $config->get('google_drive.credentials_path');
-        $this->driveClient = new GoogleDriveClient($credentialsPath);
+        $this->driveClient = $credentialsPath ? new GoogleDriveClient($credentialsPath) : null;
 
         $tempDir = $config->get('analysis.temp_dir', sys_get_temp_dir() . '/video-audio-cache');
         $this->videoProcessor = new VideoProcessor($tempDir);
@@ -37,15 +37,27 @@ class SpeechAnalysisService
         );
     }
 
-    public function processPitch(string $pitchKey, int $limit = 1): array
+    public function processPitch(string $pitchKey, int $limit = 1, ?string $localDirectory = null): array
     {
-        $folderMappings = $this->config->get('google_drive.folder_mappings', []);
-        if (!isset($folderMappings[$pitchKey])) {
-            throw new \InvalidArgumentException('Unknown pitch key: ' . $pitchKey);
+        if ($limit < 1) {
+            return [];
         }
 
-        $folderId = $folderMappings[$pitchKey];
-        $files = $this->driveClient->listFiles($folderId, $limit);
+        if ($localDirectory !== null) {
+            $files = $this->listLocalFiles($localDirectory, $limit);
+        } else {
+            $folderMappings = $this->config->get('google_drive.folder_mappings', []);
+            if (!isset($folderMappings[$pitchKey])) {
+                throw new \InvalidArgumentException('Unknown pitch key: ' . $pitchKey);
+            }
+
+            if ($this->driveClient === null) {
+                throw new \RuntimeException('Google Drive credentials are not configured.');
+            }
+
+            $folderId = $folderMappings[$pitchKey];
+            $files = $this->driveClient->listFiles($folderId, $limit);
+        }
 
         $results = [];
         foreach ($files as $file) {
@@ -57,20 +69,46 @@ class SpeechAnalysisService
 
     private function processFile(array $file): array
     {
-        $fileId = $file['id'];
-        $name = $file['name'];
-        $tempDir = sys_get_temp_dir() . '/speech-analysis';
-        if (!is_dir($tempDir)) {
-            if (!mkdir($tempDir, 0777, true) && !is_dir($tempDir)) {
-                throw new \RuntimeException('Unable to create temp directory: ' . $tempDir);
-            }
-        }
-
-        $videoPath = $tempDir . '/' . $name;
+        $name = $file['name'] ?? null;
+        $videoPath = $file['local_path'] ?? null;
+        $cleanupVideo = false;
         $audioPath = null;
 
         try {
-            $this->driveClient->downloadFile($fileId, $videoPath);
+            if ($videoPath === null) {
+                if ($this->driveClient === null) {
+                    throw new \RuntimeException('Google Drive client is not configured.');
+                }
+
+                $fileId = $file['id'] ?? null;
+                if ($fileId === null) {
+                    throw new \InvalidArgumentException('Missing file ID for Google Drive download.');
+                }
+
+                if ($name === null) {
+                    throw new \InvalidArgumentException('Missing file name for Google Drive download.');
+                }
+
+                $tempDir = sys_get_temp_dir() . '/speech-analysis';
+                if (!is_dir($tempDir)) {
+                    if (!mkdir($tempDir, 0777, true) && !is_dir($tempDir)) {
+                        throw new \RuntimeException('Unable to create temp directory: ' . $tempDir);
+                    }
+                }
+
+                $videoPath = $tempDir . '/' . $name;
+                $cleanupVideo = true;
+
+                $this->driveClient->downloadFile($fileId, $videoPath);
+            } else {
+                if ($name === null) {
+                    $name = basename($videoPath);
+                }
+
+                if (!is_file($videoPath)) {
+                    throw new \RuntimeException('Local video not found at ' . $videoPath);
+                }
+            }
 
             $audioPath = $this->videoProcessor->extractAudio($videoPath);
             $transcriptData = $this->transcriber->transcribe($audioPath);
@@ -102,12 +140,45 @@ class SpeechAnalysisService
                 'analysis' => $analysis,
             ];
         } finally {
-            if (is_file($videoPath)) {
+            if ($cleanupVideo && $videoPath && is_file($videoPath)) {
                 @unlink($videoPath);
             }
             if ($audioPath && is_file($audioPath)) {
                 @unlink($audioPath);
             }
         }
+    }
+
+    private function listLocalFiles(string $directory, int $limit): array
+    {
+        if (!is_dir($directory)) {
+            throw new \InvalidArgumentException('Local directory not found: ' . $directory);
+        }
+
+        $files = [];
+        $iterator = new \FilesystemIterator($directory, \FilesystemIterator::SKIP_DOTS);
+        foreach ($iterator as $fileInfo) {
+            if ($fileInfo->isFile()) {
+                $files[] = [
+                    'id' => null,
+                    'name' => $fileInfo->getFilename(),
+                    'local_path' => $fileInfo->getPathname(),
+                    'modifiedTime' => date('c', $fileInfo->getMTime()),
+                    'mimeType' => null,
+                    'mtime' => $fileInfo->getMTime(),
+                ];
+            }
+        }
+
+        usort($files, static function (array $a, array $b): int {
+            return $b['mtime'] <=> $a['mtime'];
+        });
+
+        $files = array_slice($files, 0, $limit);
+
+        return array_map(static function (array $file): array {
+            unset($file['mtime']);
+            return $file;
+        }, $files);
     }
 }


### PR DESCRIPTION
## Summary
- allow the analysis CLI to process videos from a local directory via a new --local-dir flag
- update SpeechAnalysisService to support local files while keeping Google Drive optional
- document the local video workflow and optional pitch flag usage in the README

## Testing
- php -l scripts/analyze_sales_pitch.php
- php -l src/SpeechAnalysisService.php

------
https://chatgpt.com/codex/tasks/task_e_68d6c79207808325865c73e9ebff897a